### PR TITLE
Accelerator param option

### DIFF
--- a/servicing.pyi
+++ b/servicing.pyi
@@ -12,6 +12,7 @@ class UserProvidedConfig:
     :param disk_size: the disk size of the service
     :param cpu: the CPU upper bound of the service
     :param memory: the memory upper bound of the service
+    :param accelerators: the GPU upper bound of the service
     :param setup: the setup command of the service
     :param run: the run command of the service
     """
@@ -24,6 +25,7 @@ class UserProvidedConfig:
                  disk_size: Optional[int] = None,
                  cpu: Optional[str] = None,
                  memory: Optional[str] = None,
+                 accelerators: Optional[str] = None,
                  setup: Optional[str] = None,
                  run: Optional[str] = None) -> None: ...
 

--- a/src/dispatcher/mod.rs
+++ b/src/dispatcher/mod.rs
@@ -517,6 +517,7 @@ mod tests {
                     run: None,
                     disk_size: None,
                     cpu: None,
+                    accelerators: None,
                     memory: None,
                 }),
             )

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -80,7 +80,7 @@ impl Configuration {
             self.resources.memory = memory.clone();
         }
         if let Some(accelerators) = &config.accelerators {
-            self.resources.accelerators = accelerators.clone();
+            self.resources.accelerators = Some(accelerators.clone());
         }
         if let Some(setup) = &config.setup {
             self.setup = setup.clone();
@@ -108,7 +108,7 @@ pub struct Resources {
     pub cloud: String,
     pub cpus: String,
     pub memory: String,
-    pub accelerators: String,
+    pub accelerators: Option<String>,
     pub disk_size: u16,
 }
 
@@ -123,6 +123,7 @@ impl Default for Configuration {
                 ports: 8080,
                 cpus: "4+".to_string(),
                 memory: "10+".to_string(),
+                accelerators: None,
                 cloud: "aws".to_string(),
                 disk_size: 100,
             },
@@ -146,6 +147,7 @@ pub fn test_config() -> Configuration {
             ports: 8080,
             cpus: "4+".to_string(),
             memory: "10+".to_string(),
+            accelerators: None,
             cloud: "aws".to_string(),
             disk_size: 50,
         },

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -11,6 +11,7 @@ pub struct UserProvidedConfig {
     pub disk_size: Option<u16>,
     pub cpu: Option<String>,
     pub memory: Option<String>,
+    pub accelerators: Option<String>,
     pub setup: Option<String>,
     pub run: Option<String>,
 }
@@ -27,6 +28,7 @@ impl UserProvidedConfig {
         disk_size: Option<u16>,
         cpu: Option<String>,
         memory: Option<String>,
+        accelerators: Option<String>,
         setup: Option<String>,
         run: Option<String>,
     ) -> Self {
@@ -38,6 +40,7 @@ impl UserProvidedConfig {
             disk_size,
             cpu,
             memory,
+            accelerators,
             setup,
             run,
         }
@@ -76,6 +79,9 @@ impl Configuration {
         if let Some(memory) = &config.memory {
             self.resources.memory = memory.clone();
         }
+        if let Some(accelerators) = &config.accelerators {
+            self.resources.accelerators = accelerators.clone();
+        }
         if let Some(setup) = &config.setup {
             self.setup = setup.clone();
         }
@@ -102,6 +108,7 @@ pub struct Resources {
     pub cloud: String,
     pub cpus: String,
     pub memory: String,
+    pub accelerators: String,
     pub disk_size: u16,
 }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -108,8 +108,9 @@ pub struct Resources {
     pub cloud: String,
     pub cpus: String,
     pub memory: String,
-    pub accelerators: Option<String>,
     pub disk_size: u16,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub accelerators: Option<String>,
 }
 
 impl Default for Configuration {


### PR DESCRIPTION
Need accelerator param as part of spec. Accelerator param default must empty.