### PR TITLE
Fix IO Error when trying to load cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,18 +1069,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.199"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
+checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.199"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
+checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "servicing"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "base64",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servicing"
-version = "0.0.8"
+version = "0.0.9"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,5 +1,5 @@
 use pyo3::{pyclass, pymethods};
-use serde::{Deserialize, Serialize};
+use serde::{ser::SerializeStruct, Deserialize, Serialize};
 
 #[pyclass]
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -102,15 +102,33 @@ pub struct Service {
     pub replicas: u16,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct Resources {
     pub ports: u16,
     pub cloud: String,
     pub cpus: String,
     pub memory: String,
     pub disk_size: u16,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub accelerators: Option<String>,
+}
+
+impl Serialize for Resources {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        let human = serializer.is_human_readable();
+        let mut stats = serializer.serialize_struct("Resources", 6)?;
+        stats.serialize_field("ports", &self.ports)?;
+        stats.serialize_field("cloud", &self.cloud)?;
+        stats.serialize_field("cpus", &self.cpus)?;
+        stats.serialize_field("memory", &self.memory)?;
+        stats.serialize_field("disk_size", &self.disk_size)?;
+        if self.accelerators.is_some() || !human {
+            stats.serialize_field("accelerators", &self.accelerators)?;
+        }
+        stats.end()
+    }
 }
 
 impl Default for Configuration {

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -117,14 +117,15 @@ impl Serialize for Resources {
     where
         S: serde::ser::Serializer,
     {
-        let human = serializer.is_human_readable();
+        let should_serialize = self.accelerators.is_some() || !serializer.is_human_readable();
+
         let mut stats = serializer.serialize_struct("Resources", 6)?;
         stats.serialize_field("ports", &self.ports)?;
         stats.serialize_field("cloud", &self.cloud)?;
         stats.serialize_field("cpus", &self.cpus)?;
         stats.serialize_field("memory", &self.memory)?;
         stats.serialize_field("disk_size", &self.disk_size)?;
-        if self.accelerators.is_some() || !human {
+        if should_serialize {
             stats.serialize_field("accelerators", &self.accelerators)?;
         }
         stats.end()


### PR DESCRIPTION
There is a bug due to skipping serialization for the accelerator field in the Resource struct. We intended to skip only for the yaml construction when value was None. This also affected binary / bincode and broke deserialization for said target.

Serialization is manually implemented to skip only for human readable format, such as yaml, when the accelerator is None. With any other case, it is not skipped.